### PR TITLE
added add freelancer rating logic

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { Request } from '@entities/Request.entity';
 import { Notification } from '@entities/Notification.entity';
 import { Offer } from '@entities/Offer.entity';
 import { Contract } from '@entities/Contract.entity';
+import { FreelancerRating } from '@entities/FreelancerRating.entity';
 import { AppController } from '@/app.controller';
 import { AppService } from '@/app.service';
 import { AuthModule } from '@/modules/auth/auth.module';
@@ -57,6 +58,7 @@ import { RequestModule } from './modules/requests/request.module';
         Offer,
         Contract,
         Favorites,
+        FreelancerRating,
       ],
       synchronize: true,
     }),

--- a/src/common/entities/Favorites.entity.ts
+++ b/src/common/entities/Favorites.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 import { User } from '@entities/User.entity';
 
 @Entity()

--- a/src/common/entities/FreelancerRating.entity.ts
+++ b/src/common/entities/FreelancerRating.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
+import { User } from '@entities/User.entity';
+
+@Entity()
+export class FreelancerRating {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ default: null, nullable: true })
+  freelancer_rating: number;
+
+  @Column({ default: null, nullable: true })
+  rating_comment: string;
+
+  @Column({ default: null, nullable: true })
+  job_id: number;
+
+  @ManyToOne(() => User, (user) => user.freelancerRating)
+  freelancer: User;
+
+  @ManyToOne(() => User, (user) => user.freelancerRating)
+  job_owner: User;
+}

--- a/src/common/entities/User.entity.ts
+++ b/src/common/entities/User.entity.ts
@@ -25,6 +25,7 @@ import { Skill } from '@entities/Skill.entity';
 import { WorkHistory } from '@entities/WorkHistory.entity';
 import { Notification } from '@entities/Notification.entity';
 import { Offer } from '@entities/Offer.entity';
+import { FreelancerRating } from '@entities/FreelancerRating.entity';
 import { Favorites } from './Favorites.entity';
 
 @Entity()
@@ -71,6 +72,9 @@ export class User {
 
   @Column({ default: null, nullable: true })
   hourly_rate: number;
+
+  @Column({ default: null, nullable: true })
+  average_rating: number;
 
   @Column({ default: null, nullable: true })
   position: string;
@@ -136,4 +140,8 @@ export class User {
   @OneToMany(() => Favorites, (favorite) => favorite.job_owner)
   @OneToMany(() => Favorites, (favorite) => favorite.freelancer)
   favorites: Favorites[];
+
+  @OneToMany(() => FreelancerRating, (frRating) => frRating.job_owner)
+  @OneToMany(() => FreelancerRating, (frRating) => frRating.freelancer)
+  freelancerRating: FreelancerRating[];
 }

--- a/src/common/mocks/users.ts
+++ b/src/common/mocks/users.ts
@@ -37,6 +37,7 @@ export const mockJobOwnerOfTypeUser: User = {
   category: null,
   password: '',
   is_google: false,
+  average_rating: 5,
   reset_password_key: '',
   workHistory: [],
   educations: [],
@@ -47,6 +48,7 @@ export const mockJobOwnerOfTypeUser: User = {
   notifications: [],
   offers: [],
   favorites: [],
+  freelancerRating: [],
 };
 
 export const mockFreelancerOfTypeUser: User = {
@@ -60,6 +62,7 @@ export const mockFreelancerOfTypeUser: User = {
   description: 'User description',
   position: 'Full stack developer',
   hourly_rate: 50,
+  average_rating: 5,
   other_experience: '',
   english_level: EnglishLevel.NO_ENGLISH,
   skills: [],
@@ -76,4 +79,5 @@ export const mockFreelancerOfTypeUser: User = {
   notifications: [],
   offers: [],
   favorites: [],
+  freelancerRating: [],
 };

--- a/src/modules/user/dto/set-freelancer-rating.dto.ts
+++ b/src/modules/user/dto/set-freelancer-rating.dto.ts
@@ -1,0 +1,21 @@
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export default class SetFreelancerRatingDto {
+  @ApiProperty({ example: 1 })
+  @IsNumber()
+  freelancer_id: number;
+
+  @ApiProperty({ example: 5 })
+  @IsNumber()
+  freelancer_rating: number;
+
+  @ApiProperty({ example: 'very good freelancer' })
+  @IsOptional()
+  @IsString()
+  rating_comment?: string;
+
+  @ApiProperty({ example: 10 })
+  @IsNumber()
+  job_id: number;
+}

--- a/src/modules/user/dto/update-user.dto.ts
+++ b/src/modules/user/dto/update-user.dto.ts
@@ -78,4 +78,9 @@ export default class UpdateUserDto {
   @IsOptional()
   @IsString()
   role?: Role;
+
+  @ApiProperty({ example: 4.3 })
+  @IsOptional()
+  @IsString()
+  average_rating?: number;
 }

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -46,6 +46,7 @@ import GetFreelancerDto from './dto/get-freelancer-params.dto';
 import getUserProposalsResponseDto from './dto/get-proposals-by-user.dto';
 import SetFavoritesDto from './dto/set-favorites.dto';
 import GetFavoritesDto from './dto/get-favorites.dto';
+import SetFreelancerRatingDto from './dto/set-freelancer-rating.dto';
 
 @ApiTags('user')
 @Controller('user')
@@ -251,5 +252,17 @@ export class UserController {
     @Request() req: ReqUser,
   ): Promise<getUserProposalsResponseDto> {
     return this.userService.getProposalsByUser(req.user);
+  }
+
+  @ApiOperation({ summary: 'set freelancer rating' })
+  @ApiHeader(getAuthorizationApiHeader())
+  @Post('/freelancerrating')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  setFreelancerRating(
+    @Request() req: ReqUser,
+    @Body() payload: SetFreelancerRatingDto,
+  ): Promise<void> {
+    return this.userService.setFreelancerRating(req.user, payload);
   }
 }

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -12,6 +12,7 @@ import { FileModule } from '@/modules/file/file.module';
 import { Job } from '@/common/entities/Job.entity';
 import { Category } from '@/common/entities/Category.entity';
 import { Favorites } from '@/common/entities/Favorites.entity';
+import { FreelancerRating } from '@/common/entities/FreelancerRating.entity';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { Favorites } from '@/common/entities/Favorites.entity';
       Job,
       Category,
       Request,
+      FreelancerRating,
       Favorites,
     ]),
     forwardRef(() => MailModule),

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -620,16 +620,17 @@ export class UserService {
             },
           ])
           .execute();
+
+        const { avg } = await this.freelancerRatingRepository
+          .createQueryBuilder('freelancerRating')
+          .where({ freelancer: { id: payload.freelancer_id } })
+          .select('AVG(freelancerRating.freelancer_rating)', 'avg')
+          .getRawOne();
+        const ratePayload = {
+          average_rating: avg,
+        };
+        await this.updateUserById(payload.freelancer_id, ratePayload);
       }
-      const { avg } = await this.freelancerRatingRepository
-        .createQueryBuilder('freelancerRating')
-        .where({ freelancer: { id: payload.freelancer_id } })
-        .select('AVG(freelancerRating.freelancer_rating)', 'avg')
-        .getRawOne();
-      const ratePayload = {
-        average_rating: avg,
-      };
-      await this.updateUserById(payload.freelancer_id, ratePayload);
     } catch (error) {
       if (error instanceof HttpException) {
         throw error;


### PR DESCRIPTION
added add freelancer rating logic:
new endpoint, POST freelancer rating data, here's swagger
![image](https://user-images.githubusercontent.com/95277626/212896646-f658e97e-a82e-46de-a65a-86916ebd3fcc.png)
can only accept data once for each job for each freelancer from each job owner
average rating is now stored in user
